### PR TITLE
optional chop the ending symbol & fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ Currently it only works for the chinese wiki.
 - replaces traditional characters with their simplified counterpart (with `-t` option)
 - ignore symbols (with `-i` option)
 - cutting long sentence with auxiliary symbols (with `-a` option)
+- choping the ending symbol of a sentence (with `-c` option)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -73,6 +73,12 @@ where
                         .takes_value(true)
                         .number_of_values(1)
                         .help("The symbols will be ignored when extracting"),
+                )
+                .arg(
+                    Arg::with_name("chop ending symbol")
+                        .short("c")
+                        .long("chop")
+                        .help("chop the ending symbol"),
                 ),
         )
         .get_matches_from(itr)
@@ -119,6 +125,7 @@ fn extract(matches: &ArgMatches) -> Result<()> {
 
     let mut builder = SentenceExtractorBuilder::new()
         .translate(matches.is_present("trans"))
+        .chop_ending_symbol(matches.is_present("chop"))
         .shortest_length(shortest_length)
         .longest_length(longest_length)
         .auxiliary_symbols(&mut auxiliary_symbols)?

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -141,3 +141,16 @@ fn test_extractor_handle_auxiliary_symbol_conflict() {
         );
     }
 }
+
+#[test]
+fn test_extractor_with_ending_symbols() {
+    let texts = load(&PathBuf::from("src/test_data/wiki_01")).unwrap();
+    let mut builder = SentenceExtractorBuilder::new().chop_ending_symbol(false);
+
+    let mut iter = builder.build(texts[0].as_str());
+    assert_eq!(iter.next().unwrap(), "春，花秋，月何時，了往事知。");
+    assert_eq!(iter.next().unwrap(), "樓昨夜。");
+    assert_eq!(iter.next().unwrap(), "又東風故。");
+    assert_eq!(iter.next().unwrap(), "國、不堪、回首月、明中雕欄。");
+    assert!(iter.next().is_none());
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8,9 +8,10 @@ fn test_extractor() {
     let mut iter = builder.build(texts[0].as_str());
 
     assert_eq!(iter.next().unwrap(), "愛因斯坦係一位理論物理學家");
+    assert_eq!(iter.next().unwrap(), "佢最出名嘅係發表咗相對論");
     assert_eq!(
         iter.next().unwrap(),
-        "佢最出名嘅係發表咗相對論，另外喺量子力學、統計力學、同埋宇宙學方面都有好大貢獻"
+        "另外喺量子力學、統計力學、同埋宇宙學方面都有好大貢獻"
     );
     assert_eq!(
         iter.next().unwrap(),
@@ -45,9 +46,12 @@ fn test_extractor() {
     );
     assert_eq!(
         iter.next().unwrap(),
-        "愛因斯坦話自己之所以諗得出相對論，正係因為細個時學嘢慢，遲過其他小朋友開始思索時空"
+        "愛因斯坦話自己之所以諗得出相對論，正係因為細個時學嘢慢"
     );
-    assert_eq!(iter.next().unwrap(), "到嗰陣思想已經比較成熟");
+    assert_eq!(
+        iter.next().unwrap(),
+        "遲過其他小朋友開始思索時空，到嗰陣思想已經比較成熟"
+    );
     assert_eq!(iter.next().unwrap(), "後來佢又寫咗好多有關時空，物質嘅理論");
     assert_eq!(
         iter.next().unwrap(),
@@ -152,5 +156,9 @@ fn test_extractor_with_ending_symbols() {
     assert_eq!(iter.next().unwrap(), "樓昨夜。");
     assert_eq!(iter.next().unwrap(), "又東風故。");
     assert_eq!(iter.next().unwrap(), "國、不堪、回首月、明中雕欄。");
+    assert_eq!(
+        iter.next().unwrap(),
+        "應在「只」是《朱》顏：改『問』君【能】有…幾—多．愁；"
+    );
     assert!(iter.next().is_none());
 }

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -132,15 +132,26 @@ lazy_static! {
 
 impl<'a> SentenceExtractor<'a> {
     fn get_cutting_point<'b>(&self, chars: &'b Vec<char>) -> Option<(usize, Option<&'b char>)> {
+        let mut previous_cuting_point = None;
         for (idx, c) in chars.iter().enumerate() {
-            if (idx >= self.longest_length && self.auxiliary_symbols.contains(&c))
-                || TERMINAL_PUNCTUATIONS.contains(&c)
-            {
+            if TERMINAL_PUNCTUATIONS.contains(&c) {
                 if c.is_whitespace() {
                     return Some((idx, None));
                 } else {
                     return Some((idx, Some(c)));
                 }
+            }
+
+            if self.auxiliary_symbols.contains(&c) {
+                previous_cuting_point = if c.is_whitespace() {
+                    Some((idx, None))
+                } else {
+                    Some((idx, Some(c)))
+                };
+            };
+
+            if idx >= self.longest_length && previous_cuting_point.is_some() {
+                return previous_cuting_point;
             }
         }
         return None;


### PR DESCRIPTION
- optional chop the ending symbol
  - add an option to chop the ending symbols
  - add test case for reserving ending symbols

- cutting sentence before it reach the longest length
  - fix the test case with too long sentence output
-  avoid normalized & disambiguate test in each iteration